### PR TITLE
Remove Google Drive desktop.ini files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/desktop.ini
+**/.DS_Store
+**/Icon

--- a/backups/desktop.ini
+++ b/backups/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=16
-    

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=16
-    

--- a/fonts/desktop.ini
+++ b/fonts/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=16
-    

--- a/images/desktop.ini
+++ b/images/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=16
-    

--- a/ref/desktop.ini
+++ b/ref/desktop.ini
@@ -1,5 +1,0 @@
-[.ShellClassInfo]
-InfoTip=This folder is shared online.
-IconFile=C:\Program Files (x86)\Google\Drive\googledrivesync.exe
-IconIndex=16
-    


### PR DESCRIPTION
These desktop.ini files simply pollute your repository. You can safely delete them, as this pull request does.